### PR TITLE
feat: AI-powered asset generation (OpenCode)

### DIFF
--- a/.opencode/opencode.jsonc
+++ b/.opencode/opencode.jsonc
@@ -19,4 +19,10 @@
     "github-triage": false,
     "github-pr-search": false,
   },
+  "asset_provider": {
+    "replicate": {
+      "api_key_env": "REPLICATE_API_TOKEN",
+      "enabled": true
+    }
+  },
 }

--- a/bun.lock
+++ b/bun.lock
@@ -323,6 +323,7 @@
         "opentui-spinner": "0.0.6",
         "partial-json": "0.1.7",
         "remeda": "catalog:",
+        "replicate": "1.4.0",
         "solid-js": "catalog:",
         "strip-ansi": "7.1.2",
         "tree-sitter-bash": "0.25.0",
@@ -3455,6 +3456,8 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "remeda": ["remeda@2.26.0", "", { "dependencies": { "type-fest": "^4.41.0" } }, "sha512-lmNNwtaC6Co4m0WTTNoZ/JlpjEqAjPZO0+czC9YVRQUpkbS4x8Hmh+Mn9HPfJfiXqUQ5IXXgSXSOB2pBKAytdA=="],
+
+    "replicate": ["replicate@1.4.0", "", { "optionalDependencies": { "readable-stream": ">=4.0.0" } }, "sha512-1ufKejfUVz/azy+5TnzQP7U1+MHVWZ6psnQ06az8byUUnRhT+DZ/MvewzB1NQYBVMgNKR7xPDtTwlcP5nv/5+w=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -108,6 +108,7 @@
     "opentui-spinner": "0.0.6",
     "partial-json": "0.1.7",
     "remeda": "catalog:",
+    "replicate": "1.4.0",
     "solid-js": "catalog:",
     "strip-ansi": "7.1.2",
     "tree-sitter-bash": "0.25.0",

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -1043,6 +1043,7 @@ export namespace Config {
           z.string(),
           z.object({
             api_key_env: z.string().optional().describe("Environment variable name for API key"),
+            api_key: z.string().optional().describe("Direct API key (synced from editor settings)"),
             api_url: z.string().optional().describe("Override base API URL"),
             enabled: z.boolean().default(true),
             default_models: z
@@ -1052,7 +1053,7 @@ export namespace Config {
           }),
         )
         .optional()
-        .describe("Asset generation provider configurations (meshy, doubao, suno)"),
+        .describe("Asset generation provider configurations (replicate, meshy, doubao, suno)"),
       compaction: z
         .object({
           auto: z.boolean().optional().describe("Enable automatic compaction when context is full (default: true)"),

--- a/packages/opencode/src/provider/asset/asset-provider.ts
+++ b/packages/opencode/src/provider/asset/asset-provider.ts
@@ -166,7 +166,7 @@ export namespace AssetProvider {
     transform(request: TransformRequest): Promise<GenerationResult>
   }
 
-  // ── Asset Metadata (stored in .ai.json sidecar) ─────────────────────
+  // ── Asset Metadata (stored in .ai.{filename}/metadata.json) ─────────
 
   export const AssetMetadata = z.object({
     origin: Origin,
@@ -211,6 +211,7 @@ export namespace AssetProvider {
 
   export const ProviderConfig = z.object({
     api_key_env: z.string().optional().describe("Environment variable name for API key"),
+    api_key: z.string().optional().describe("Direct API key (synced from editor settings)"),
     api_url: z.string().optional().describe("Override base API URL"),
     enabled: z.boolean().default(true),
     default_models: z

--- a/packages/opencode/src/provider/asset/index.ts
+++ b/packages/opencode/src/provider/asset/index.ts
@@ -4,6 +4,7 @@ import { AssetProvider } from "./asset-provider"
 import { MeshyProvider } from "./meshy"
 import { DoubaoProvider } from "./doubao"
 import { SunoProvider } from "./suno"
+import { ReplicateProvider } from "./replicate"
 
 /**
  * Central registry for asset generation providers.
@@ -24,6 +25,7 @@ export namespace AssetProviderRegistry {
     string,
     (config: { apiKey: string; apiUrl?: string }) => AssetProvider.Provider
   > = {
+    replicate: (config) => new ReplicateProvider(config),
     meshy: (config) => new MeshyProvider(config),
     doubao: (config) => new DoubaoProvider(config),
     suno: (config) => new SunoProvider(config),
@@ -34,10 +36,10 @@ export namespace AssetProviderRegistry {
     model: "meshy",
     mesh: "meshy",
     scene: "meshy",
-    texture: "doubao",
-    sprite: "doubao",
-    cubemap: "doubao",
-    material: "doubao",
+    texture: "replicate",
+    sprite: "replicate",
+    cubemap: "replicate",
+    material: "replicate",
     audio_sfx: "suno",
     audio_music: "suno",
   }
@@ -88,13 +90,13 @@ export namespace AssetProviderRegistry {
         continue
       }
 
-      // Resolve API key from env var
-      const envVar = providerConfig.api_key_env
-      const apiKey = envVar ? process.env[envVar] : undefined
+      // Resolve API key: direct key takes precedence over env var
+      const apiKey = providerConfig.api_key
+        ?? (providerConfig.api_key_env ? process.env[providerConfig.api_key_env] : undefined)
       if (!apiKey) {
         log.warn("asset provider missing API key", {
           id: providerId,
-          env: envVar ?? "(not configured)",
+          env: providerConfig.api_key_env ?? "(not configured)",
         })
         continue
       }
@@ -111,6 +113,46 @@ export namespace AssetProviderRegistry {
       count: providers.size,
       ids: Array.from(providers.keys()),
     })
+  }
+
+  // ── Runtime Configuration ─────────────────────────────────────────────
+
+  /**
+   * Configure and register a provider at runtime with a direct API key.
+   * Used by the Settings dialog and /connect chat command.
+   */
+  export async function configureProvider(
+    providerId: string,
+    apiKey: string,
+    apiUrl?: string,
+  ): Promise<{ success: boolean; error?: string }> {
+    const factory = BUILTIN_FACTORIES[providerId]
+    if (!factory) {
+      return { success: false, error: `Unknown provider: ${providerId}` }
+    }
+
+    const provider = factory({ apiKey, apiUrl })
+
+    // Validate the key if the provider supports it
+    if ("validateApiKey" in provider && typeof (provider as any).validateApiKey === "function") {
+      const valid = await (provider as any).validateApiKey()
+      if (!valid) {
+        return { success: false, error: "Invalid API key" }
+      }
+    }
+
+    register(provider)
+    log.info("asset provider configured at runtime", { id: providerId })
+    return { success: true }
+  }
+
+  /** Get status of all registered providers (with masked keys for display) */
+  export function status(): Array<{ id: string; name: string; supportedTypes: AssetProvider.AssetType[] }> {
+    return Array.from(providers.values()).map((p) => ({
+      id: p.id,
+      name: p.name,
+      supportedTypes: p.supportedTypes,
+    }))
   }
 
   // ── Model Discovery ──────────────────────────────────────────────────

--- a/packages/opencode/src/provider/asset/metadata.ts
+++ b/packages/opencode/src/provider/asset/metadata.ts
@@ -3,33 +3,30 @@ import fs from "fs/promises"
 import { AssetProvider } from "./asset-provider"
 
 /**
- * Asset metadata utilities for reading/writing .ai.json sidecar files.
+ * Asset metadata utilities for reading/writing AI metadata.
  *
- * Sidecar files store extended AI-related metadata alongside assets:
- *   - res://assets/knight.png → res://assets/knight.png.ai.json
+ * All metadata is stored in `.ai.{filename}/metadata.json` (version dir).
+ *   - res://assets/knight.png → res://assets/.ai.knight.png/metadata.json
  */
 export namespace AssetMetadata {
-  /** Get the sidecar path for an asset file */
-  export function sidecarPath(assetPath: string): string {
-    return `${assetPath}.ai.json`
-  }
-
-  /** Read metadata from sidecar file (returns undefined if not found) */
+  /** Read metadata from version dir metadata.json */
   export async function read(assetPath: string): Promise<AssetProvider.AssetMetadata | undefined> {
-    const sidecar = sidecarPath(assetPath)
+    const verIndex = getVersionIndexPath(assetPath)
     try {
-      const content = await fs.readFile(sidecar, "utf-8")
+      const content = await fs.readFile(verIndex, "utf-8")
       return AssetProvider.AssetMetadata.parse(JSON.parse(content))
     } catch {
       return undefined
     }
   }
 
-  /** Write metadata to sidecar file */
+  /** Write metadata to version dir metadata.json */
   export async function write(assetPath: string, metadata: AssetProvider.AssetMetadata): Promise<void> {
-    const sidecar = sidecarPath(assetPath)
+    const verDir = getVersionDir(assetPath)
+    await fs.mkdir(verDir, { recursive: true })
+    const verIndex = getVersionIndexPath(assetPath)
     const content = JSON.stringify(metadata, null, 2)
-    await fs.writeFile(sidecar, content, "utf-8")
+    await fs.writeFile(verIndex, content, "utf-8")
   }
 
   /** Update metadata (merge with existing) */
@@ -63,11 +60,11 @@ export namespace AssetMetadata {
     return merged
   }
 
-  /** Delete metadata sidecar */
+  /** Delete all AI metadata (entire .ai.{filename}/ directory) */
   export async function remove(assetPath: string): Promise<void> {
-    const sidecar = sidecarPath(assetPath)
+    const verDir = getVersionDir(assetPath)
     try {
-      await fs.unlink(sidecar)
+      await fs.rm(verDir, { recursive: true, force: true })
     } catch {
       // Ignore if doesn't exist
     }
@@ -243,9 +240,8 @@ export namespace AssetMetadata {
 
   /** Check if asset has AI metadata */
   export async function exists(assetPath: string): Promise<boolean> {
-    const sidecar = sidecarPath(assetPath)
     try {
-      await fs.access(sidecar)
+      await fs.access(getVersionIndexPath(assetPath))
       return true
     } catch {
       return false

--- a/packages/opencode/src/provider/asset/replicate.ts
+++ b/packages/opencode/src/provider/asset/replicate.ts
@@ -1,0 +1,403 @@
+import Replicate from "replicate"
+import { Log } from "../../util/log"
+import { AssetProvider } from "./asset-provider"
+
+/**
+ * Replicate provider for 2D image/texture generation.
+ *
+ * Uses Replicate's Node.js SDK with built-in progress callbacks and auto-polling.
+ * Supports Stable Diffusion 3.5, SDXL, and other open-source image models.
+ */
+export class ReplicateProvider implements AssetProvider.Provider {
+  readonly id = "replicate"
+  readonly name = "Replicate"
+  readonly supportedTypes: AssetProvider.AssetType[] = [
+    "texture",
+    "sprite",
+    "cubemap",
+    "material",
+  ]
+
+  private client: Replicate
+  private log = Log.create({ service: "asset.replicate" })
+
+  /** In-memory cache of completed prediction outputs keyed by generationId */
+  private resultCache = new Map<
+    string,
+    { status: AssetProvider.GenerationStatus["status"]; output?: string[]; message?: string }
+  >()
+
+  /** In-memory cache of downloaded asset bundles to avoid re-fetching from CDN */
+  private bundleCache = new Map<string, AssetProvider.AssetBundle>()
+
+  /** Models that use aspect_ratio instead of width/height */
+  private static readonly ASPECT_RATIO_MODELS = new Set(["sd-3.5-medium", "sd-3.5-large-turbo", "flux-schnell"])
+
+  /** Models that use cfg instead of guidance_scale */
+  private static readonly CFG_MODELS = new Set(["sd-3.5-medium", "sd-3.5-large-turbo"])
+
+  /** Models that do NOT support negative_prompt */
+  private static readonly NO_NEGATIVE_PROMPT = new Set(["flux-schnell"])
+
+  /** Model identifier → Replicate model string mapping */
+  private static readonly MODELS: Record<string, {
+    ref: `${string}/${string}` | `${string}/${string}:${string}`;
+    description: string;
+    cost: number;
+  }> = {
+    "sd-3.5-medium": {
+      ref: "stability-ai/stable-diffusion-3.5-medium",
+      description: "Stable Diffusion 3.5 Medium — balanced quality and speed",
+      cost: 0.035,
+    },
+    "sd-3.5-large-turbo": {
+      ref: "stability-ai/stable-diffusion-3.5-large-turbo",
+      description: "Stable Diffusion 3.5 Large Turbo — fast, high quality",
+      cost: 0.04,
+    },
+    "sdxl": {
+      ref: "stability-ai/sdxl:7762fd07cf82c948538e41f63f77d685e02b063e37e496e96eefd46c929f9bdc",
+      description: "Stable Diffusion XL — high-resolution image generation",
+      cost: 0.0055,
+    },
+    "flux-schnell": {
+      ref: "black-forest-labs/flux-schnell",
+      description: "FLUX.1 Schnell — fast text-to-image",
+      cost: 0.003,
+    },
+  }
+
+  constructor(config: { apiKey: string; apiUrl?: string }) {
+    this.client = new Replicate({ auth: config.apiKey, useFileOutput: false })
+  }
+
+  async listModels(): Promise<AssetProvider.ModelInfo[]> {
+    return Object.entries(ReplicateProvider.MODELS).map(([id, model]) => ({
+      id,
+      name: id,
+      description: model.description,
+      supportedTypes: ["texture", "sprite", "cubemap", "material"] as AssetProvider.AssetType[],
+      supportedTransforms: ["variation"] as AssetProvider.TransformType[],
+      pricing: { unit: "per image", cost: model.cost },
+      parameters: [
+        {
+          name: "width",
+          type: "number" as const,
+          description: "Image width in pixels",
+          default: 768,
+          min: 64,
+          max: 1024,
+        },
+        {
+          name: "height",
+          type: "number" as const,
+          description: "Image height in pixels",
+          default: 768,
+          min: 64,
+          max: 1024,
+        },
+        {
+          name: "num_outputs",
+          type: "number" as const,
+          description: "Number of images to generate",
+          default: 1,
+          min: 1,
+          max: 4,
+        },
+        {
+          name: "scheduler",
+          type: "enum" as const,
+          description: "Diffusion scheduler algorithm",
+          default: "DPMSolverMultistep",
+          options: ["DDIM", "K_EULER", "DPMSolverMultistep", "K_EULER_ANCESTRAL", "PNDM", "KLMS"],
+        },
+        {
+          name: "num_inference_steps",
+          type: "number" as const,
+          description: "Number of denoising steps (more = higher quality, slower)",
+          default: 50,
+          min: 1,
+          max: 500,
+        },
+        {
+          name: "guidance_scale",
+          type: "number" as const,
+          description: "Classifier-free guidance scale (higher = more prompt adherence)",
+          default: 7.5,
+          min: 1,
+          max: 20,
+        },
+      ],
+    }))
+  }
+
+  async generate(request: AssetProvider.GenerationRequest): Promise<AssetProvider.GenerationResult> {
+    const modelId = request.model ?? "sd-3.5-large-turbo"
+    const modelEntry = ReplicateProvider.MODELS[modelId]
+
+    if (!modelEntry) {
+      throw new Error(`Unknown Replicate model: ${modelId}. Available: ${Object.keys(ReplicateProvider.MODELS).join(", ")}`)
+    }
+
+    const input: Record<string, unknown> = {
+      prompt: request.prompt,
+    }
+
+    if (request.negativePrompt && !ReplicateProvider.NO_NEGATIVE_PROMPT.has(modelId)) {
+      input.negative_prompt = request.negativePrompt
+    }
+    if (request.parameters.seed) input.seed = request.parameters.seed
+    if (request.parameters.num_outputs) input.num_outputs = request.parameters.num_outputs
+
+    if (ReplicateProvider.ASPECT_RATIO_MODELS.has(modelId)) {
+      // Aspect-ratio models: convert width/height to closest ratio
+      const w = (request.parameters.width as number) || 768
+      const h = (request.parameters.height as number) || 768
+      input.aspect_ratio = ReplicateProvider.findClosestAspectRatio(w, h, modelId)
+
+      // Parse target size from metadata (e.g., "32x44") for aspect ratio
+      if (request.parameters.size) {
+        const match = String(request.parameters.size).match(/^(\d+)x(\d+)$/)
+        if (match) {
+          input.aspect_ratio = ReplicateProvider.findClosestAspectRatio(parseInt(match[1]), parseInt(match[2]), modelId)
+        }
+      }
+
+      input.output_format = "png"
+
+      // SD 3.5 models use "cfg" instead of "guidance_scale"
+      if (ReplicateProvider.CFG_MODELS.has(modelId)) {
+        input.cfg = request.parameters.guidance_scale ?? (modelId === "sd-3.5-large-turbo" ? 1 : 5)
+      }
+
+      // flux-schnell: num_inference_steps capped at 4
+      if (modelId === "flux-schnell") {
+        input.num_inference_steps = Math.min(request.parameters.num_inference_steps ?? 4, 4)
+      }
+    } else {
+      // SDXL and other width/height models
+      if (request.parameters.width) input.width = request.parameters.width
+      if (request.parameters.height) input.height = request.parameters.height
+      if (request.parameters.scheduler) input.scheduler = request.parameters.scheduler
+      if (request.parameters.num_inference_steps) input.num_inference_steps = request.parameters.num_inference_steps
+      if (request.parameters.guidance_scale) input.guidance_scale = request.parameters.guidance_scale
+
+      // Parse target size from metadata (e.g., "32x44", "96x24") and set API dimensions
+      if (request.parameters.size && !input.width && !input.height) {
+        const match = String(request.parameters.size).match(/^(\d+)x(\d+)$/)
+        if (match) {
+          const targetW = parseInt(match[1])
+          const targetH = parseInt(match[2])
+          // Snap to nearest multiple of 64, clamped to [64, 1024]
+          input.width = Math.max(64, Math.min(1024, Math.round(targetW / 64) * 64 || 64))
+          input.height = Math.max(64, Math.min(1024, Math.round(targetH / 64) * 64 || 64))
+        }
+      }
+    }
+
+    this.log.info("creating replicate prediction", { model: modelEntry.ref, prompt: request.prompt })
+
+    const generationId = `rep-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+
+    // Track progress
+    this.resultCache.set(generationId, { status: "processing" })
+
+    // Run asynchronously with progress callback
+    this.runPrediction(generationId, modelEntry.ref, input)
+
+    return {
+      generationId,
+      status: "processing",
+    }
+  }
+
+  private async runPrediction(
+    generationId: string,
+    modelRef: `${string}/${string}` | `${string}/${string}:${string}`,
+    input: Record<string, unknown>,
+  ): Promise<void> {
+    try {
+      const output = await this.client.run(modelRef, { input }, (prediction) => {
+        this.log.info("replicate progress", {
+          id: generationId,
+          status: prediction.status,
+        })
+      })
+
+      // Output is an array of FileOutput objects or URLs
+      const urls = this.extractUrls(output)
+
+      this.resultCache.set(generationId, { status: "completed", output: urls })
+      this.log.info("replicate prediction completed", { id: generationId, outputCount: urls.length })
+    } catch (error: any) {
+      this.log.error("replicate prediction failed", { id: generationId, error: error.message })
+      this.resultCache.set(generationId, { status: "failed", message: error.message })
+    }
+  }
+
+  private extractUrls(output: unknown): string[] {
+    this.log.info("extractUrls input", { type: typeof output, isArray: Array.isArray(output), value: String(output).slice(0, 200) })
+    if (Array.isArray(output)) {
+      return output.map((item, i) => {
+        if (typeof item === "string") return item
+        if (item && typeof item === "object" && "url" in item) {
+          const url = typeof (item as any).url === "function" ? String((item as any).url()) : String((item as any).url)
+          this.log.info("extractUrls FileOutput", { index: i, url: url.slice(0, 100) })
+          return url
+        }
+        this.log.warn("extractUrls unknown item type", { index: i, type: typeof item, value: String(item).slice(0, 100) })
+        return String(item)
+      })
+    }
+    if (typeof output === "string") return [output]
+    this.log.warn("extractUrls: empty output", { type: typeof output })
+    return []
+  }
+
+  async checkStatus(generationId: string): Promise<AssetProvider.GenerationStatus> {
+    const cached = this.resultCache.get(generationId)
+    if (!cached) {
+      return {
+        generationId,
+        status: "failed",
+        message: "Prediction not found",
+      }
+    }
+
+    return {
+      generationId,
+      status: cached.status,
+      progress: cached.status === "completed" ? 100 : cached.status === "processing" ? 50 : 0,
+      ...(cached.message ? { message: cached.message } : {}),
+    }
+  }
+
+  async download(generationId: string): Promise<AssetProvider.AssetBundle> {
+    // Return cached bundle if already downloaded (avoids re-fetching from CDN)
+    const cachedBundle = this.bundleCache.get(generationId)
+    if (cachedBundle) {
+      return cachedBundle
+    }
+
+    const cached = this.resultCache.get(generationId)
+    if (!cached || !cached.output?.length) {
+      throw new Error(`No output available for prediction ${generationId}`)
+    }
+
+    const assets: AssetProvider.BundleAsset[] = []
+
+    for (let i = 0; i < cached.output.length; i++) {
+      const url = cached.output[i]
+      const { data, extension } = await this.downloadFileWithFormat(url)
+
+      assets.push({
+        type: "texture",
+        role: i === 0 ? "primary" : "texture",
+        data,
+        filename: `image_${i}${extension}`,
+        metadata: {
+          source_url: url,
+          index: i,
+        },
+      })
+    }
+
+    const bundle: AssetProvider.AssetBundle = {
+      bundleId: generationId,
+      assets,
+    }
+    this.bundleCache.set(generationId, bundle)
+    return bundle
+  }
+
+  supportsTransform(transform: AssetProvider.TransformType): boolean {
+    return ["variation"].includes(transform)
+  }
+
+  async transform(request: AssetProvider.TransformRequest): Promise<AssetProvider.GenerationResult> {
+    if (request.transform !== "variation") {
+      throw new Error(`Replicate does not support transform: ${request.transform}`)
+    }
+
+    // Use img2img via stable-diffusion with image input
+    const input: Record<string, unknown> = {
+      prompt: request.prompt ?? "variation of the input image",
+      image: `data:image/png;base64,${request.sourceFile.toString("base64")}`,
+      prompt_strength: request.parameters.strength ?? 0.6,
+    }
+
+    const generationId = `rep-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    this.resultCache.set(generationId, { status: "processing" })
+    this.runPrediction(generationId, ReplicateProvider.MODELS["sdxl"].ref, input)
+
+    return {
+      generationId,
+      status: "processing",
+    }
+  }
+
+  private async downloadFileWithFormat(url: string): Promise<{ data: Buffer; extension: string }> {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error(`Failed to download file from Replicate: ${response.status}`)
+    }
+    const arrayBuffer = await response.arrayBuffer()
+    const data = Buffer.from(arrayBuffer)
+
+    // Detect actual format from magic bytes — Replicate often returns WebP despite URL ending in .png
+    const extension = this.detectImageExtension(data)
+    return { data, extension }
+  }
+
+  private detectImageExtension(data: Buffer): string {
+    if (data.length < 4) return ".png"
+    // PNG: 89 50 4E 47
+    if (data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47) return ".png"
+    // JPEG: FF D8 FF
+    if (data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) return ".jpg"
+    // WebP: RIFF....WEBP
+    if (data[0] === 0x52 && data[1] === 0x49 && data[2] === 0x46 && data[3] === 0x46 && data.length >= 12 &&
+        data[8] === 0x57 && data[9] === 0x45 && data[10] === 0x42 && data[11] === 0x50) return ".webp"
+    // Default to PNG
+    return ".png"
+  }
+
+  /** SD 3.5 accepted aspect ratios */
+  private static readonly SD35_RATIOS: [string, number][] = [
+    ["1:1", 1], ["16:9", 16/9], ["21:9", 21/9], ["3:2", 3/2], ["2:3", 2/3],
+    ["4:5", 4/5], ["5:4", 5/4], ["9:16", 9/16], ["9:21", 9/21],
+  ]
+
+  /** Flux-schnell accepted aspect ratios (superset with 3:4, 4:3) */
+  private static readonly FLUX_RATIOS: [string, number][] = [
+    ["1:1", 1], ["16:9", 16/9], ["21:9", 21/9], ["3:2", 3/2], ["2:3", 2/3],
+    ["4:5", 4/5], ["5:4", 5/4], ["3:4", 3/4], ["4:3", 4/3], ["9:16", 9/16], ["9:21", 9/21],
+  ]
+
+  /** Pick the closest valid aspect ratio from width/height for a given model */
+  private static findClosestAspectRatio(w: number, h: number, modelId: string): string {
+    const ratios = modelId === "flux-schnell" ? ReplicateProvider.FLUX_RATIOS : ReplicateProvider.SD35_RATIOS
+    const target = w / h
+    let best = ratios[0][0]
+    let bestDiff = Math.abs(target - ratios[0][1])
+    for (const [label, ratio] of ratios) {
+      const diff = Math.abs(target - ratio)
+      if (diff < bestDiff) {
+        best = label
+        bestDiff = diff
+      }
+    }
+    return best
+  }
+
+  /** Quick validation that the API key works */
+  async validateApiKey(): Promise<boolean> {
+    try {
+      // List models is a lightweight call to verify the token
+      await this.client.models.list()
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/packages/opencode/src/server/routes/ai-assets.ts
+++ b/packages/opencode/src/server/routes/ai-assets.ts
@@ -1,10 +1,12 @@
 import { Hono } from "hono"
 import { describeRoute, validator, resolver } from "hono-openapi"
 import z from "zod"
+import { generateText } from "ai"
 import { lazy } from "../../util/lazy"
 import { AssetProviderRegistry } from "../../provider/asset"
 import { AssetProvider } from "../../provider/asset/asset-provider"
 import { AssetMetadata } from "../../provider/asset/metadata"
+import { Provider } from "../../provider/provider"
 import { Instance } from "../../project/instance"
 import path from "path"
 import fs from "fs/promises"
@@ -47,6 +49,77 @@ export const AIAssetRoutes = lazy(() =>
             supportedTypes: p.supportedTypes,
           })),
         )
+      },
+    )
+
+    .get(
+      "/providers/status",
+      describeRoute({
+        summary: "Asset provider status",
+        description: "Get status of all configured asset generation providers.",
+        operationId: "ai-assets.providers.status",
+        responses: {
+          200: {
+            description: "Provider status list",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.array(
+                    z.object({
+                      id: z.string(),
+                      name: z.string(),
+                      supportedTypes: z.array(AssetProvider.AssetType),
+                    }),
+                  ),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      async (c) => {
+        return c.json(AssetProviderRegistry.status())
+      },
+    )
+
+    .post(
+      "/providers/configure",
+      describeRoute({
+        summary: "Configure asset provider",
+        description: "Configure an asset generation provider at runtime with an API key.",
+        operationId: "ai-assets.providers.configure",
+        responses: {
+          200: {
+            description: "Configuration result",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    success: z.boolean(),
+                    error: z.string().optional(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          providerId: z.string(),
+          apiKey: z.string(),
+          apiUrl: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const { providerId, apiKey, apiUrl } = c.req.valid("json" as never) as {
+          providerId: string
+          apiKey: string
+          apiUrl?: string
+        }
+        const result = await AssetProviderRegistry.configureProvider(providerId, apiKey, apiUrl)
+        return c.json(result)
       },
     )
 
@@ -111,7 +184,12 @@ export const AIAssetRoutes = lazy(() =>
             description: "Generation started",
             content: {
               "application/json": {
-                schema: resolver(AssetProvider.GenerationResult),
+                schema: resolver(
+                  AssetProvider.GenerationResult.extend({
+                    providerId: z.string(),
+                    model: z.string(),
+                  }),
+                ),
               },
             },
           },
@@ -129,9 +207,21 @@ export const AIAssetRoutes = lazy(() =>
       ),
       async (c) => {
         const body = c.req.valid("json" as never) as AssetProvider.GenerationRequest
-        const { provider, modelId } = await AssetProviderRegistry.resolveModel(body.type, body.model)
+        let resolved
+        try {
+          resolved = await AssetProviderRegistry.resolveModel(body.type, body.model)
+        } catch (e: any) {
+          return c.json({ error: e.message }, 400)
+        }
+        const { provider, modelId } = resolved
         const result = await provider.generate({ ...body, model: modelId })
-        return c.json(result)
+        return c.json({
+          generationId: result.generationId,
+          status: result.status,
+          estimatedTime: result.estimatedTime,
+          providerId: provider.id,
+          model: modelId,
+        })
       },
     )
 
@@ -293,7 +383,12 @@ export const AIAssetRoutes = lazy(() =>
             description: "Transform job started",
             content: {
               "application/json": {
-                schema: resolver(AssetProvider.GenerationResult),
+                schema: resolver(
+                  AssetProvider.GenerationResult.extend({
+                    providerId: z.string(),
+                    model: z.string().optional(),
+                  }),
+                ),
               },
             },
           },
@@ -326,7 +421,7 @@ export const AIAssetRoutes = lazy(() =>
         }
 
         const provider = providers[0]
-        const result = await provider.transform({
+        const result = await provider.transform!({
           sourceFile: Buffer.from(body.sourceBase64, "base64"),
           sourceType: body.sourceType,
           transform: body.transform,
@@ -335,7 +430,13 @@ export const AIAssetRoutes = lazy(() =>
           parameters: body.parameters,
         })
 
-        return c.json(result)
+        return c.json({
+          generationId: result.generationId,
+          status: result.status,
+          estimatedTime: result.estimatedTime,
+          providerId: provider.id,
+          model: body.model,
+        })
       },
     )
 
@@ -360,6 +461,70 @@ export const AIAssetRoutes = lazy(() =>
       }),
       async (c) => {
         return c.json(AssetProviderRegistry.supportedTypes())
+      },
+    )
+
+    // ── Prompt Refinement ──────────────────────────────────────────────
+
+    .post(
+      "/refine-prompt",
+      describeRoute({
+        summary: "Refine an asset generation prompt",
+        description:
+          "Use an LLM to refine an asset generation prompt based on user instructions.",
+        operationId: "ai-assets.refine-prompt",
+        responses: {
+          200: {
+            description: "Refined prompt",
+            content: {
+              "application/json": {
+                schema: resolver(
+                  z.object({
+                    refinedPrompt: z.string(),
+                  }),
+                ),
+              },
+            },
+          },
+        },
+      }),
+      validator(
+        "json",
+        z.object({
+          prompt: z.string(),
+          instruction: z.string(),
+          assetType: z.string().optional(),
+        }),
+      ),
+      async (c) => {
+        const { prompt, instruction, assetType } = c.req.valid("json" as never) as {
+          prompt: string
+          instruction: string
+          assetType?: string
+        }
+
+        const defaultModel = await Provider.defaultModel()
+        const model = await Provider.getModel(defaultModel.providerID, defaultModel.modelID)
+        const language = await Provider.getLanguage(model)
+
+        const typeHint = assetType ? ` The asset type is "${assetType}".` : ""
+
+        const result = await generateText({
+          model: language,
+          messages: [
+            {
+              role: "system",
+              content: `You are an expert at writing prompts for AI asset generation in game development. The user will give you an existing prompt and an instruction for how to refine it. Return ONLY the refined prompt text — no explanations, no quotes, no markdown.${typeHint}`,
+            },
+            {
+              role: "user",
+              content: `Current prompt: ${prompt}\n\nInstruction: ${instruction}`,
+            },
+          ],
+          temperature: 0.3,
+        })
+
+        return c.json({ refinedPrompt: result.text.trim() })
       },
     )
 

--- a/packages/opencode/src/tool/godot-ai-asset.ts
+++ b/packages/opencode/src/tool/godot-ai-asset.ts
@@ -11,15 +11,16 @@ import type { AssetProvider } from "../provider/asset/asset-provider"
 // godot_asset_generate - Generate any asset type via configured provider
 // =============================================================================
 
-const GENERATE_DESCRIPTION = `Generate a new asset using AI providers (Meshy for 3D, Doubao for 2D, Suno for audio).
+const GENERATE_DESCRIPTION = `Generate REAL assets immediately using AI providers (requires provider configuration).
 
-This tool:
-1. Routes to the appropriate AI provider based on asset type
-2. Generates the asset from the given prompt
-3. Downloads and imports the result into the Godot project
-4. Creates metadata tracking generation parameters
+IMPORTANT: Do NOT use this tool for normal game development. Use godot_asset_create_placeholder instead.
 
-Use when the user wants to create new assets from text descriptions.`
+ONLY use this tool when:
+- User explicitly says "generate REAL assets NOW" or "generate with AI NOW"
+- AI providers are already configured
+- User has confirmed they want to wait for real AI generation (slow, costs money)
+
+For normal game development, ALWAYS use godot_asset_create_placeholder to create placeholders first.`
 
 export const GodotAssetGenerateTool = Tool.define("godot_asset_generate", {
   description: GENERATE_DESCRIPTION,
@@ -47,10 +48,11 @@ export const GodotAssetGenerateTool = Tool.define("godot_asset_generate", {
     parameters: z.record(z.string(), z.any()).optional().describe("Provider-specific parameters"),
   }),
   async execute(params, ctx) {
-    const registry = AssetProviderRegistry.getInstance()
-
     // 1. Resolve provider + model
-    const resolved = registry.resolveModel(params.type as AssetProvider.AssetType, params.model)
+    const resolved = await AssetProviderRegistry.resolveModel(
+      params.type as AssetProvider.AssetType,
+      params.model,
+    )
     if (!resolved) {
       return {
         title: "Generation failed",
@@ -152,15 +154,16 @@ export const GodotAssetGenerateTool = Tool.define("godot_asset_generate", {
 // godot_asset_create_placeholder - Create placeholder with pre-filled metadata
 // =============================================================================
 
-const PLACEHOLDER_DESCRIPTION = `Create a placeholder asset with pre-filled AI generation metadata.
+const PLACEHOLDER_DESCRIPTION = `Creates game asset placeholders (textures, sprites, 3D models, audio) that work immediately and can be AI-generated later.
 
-Use this when generating game code that needs assets - create placeholders that can be
-generated later. This allows the game to run immediately with placeholder visuals.
+WHEN TO USE: User requests ANY game asset - textures, sprites, images, sounds, music, models, meshes, etc.
 
-The placeholder:
-- Is a simple colored shape or empty resource
-- Contains full generation metadata (prompt, provider, model, parameters)
-- Can be generated later with /generate-assets or right-click menu`
+How it works:
+- Creates working placeholder immediately (colored rectangle, basic mesh, silent audio)
+- Stores your generation prompt for later AI generation
+- User can right-click asset in Godot to generate real version with AI
+
+DO NOT write GDScript code to generate images/textures programmatically. Use this tool instead.`
 
 export const GodotAssetCreatePlaceholderTool = Tool.define("godot_asset_create_placeholder", {
   description: PLACEHOLDER_DESCRIPTION,
@@ -180,7 +183,7 @@ export const GodotAssetCreatePlaceholderTool = Tool.define("godot_asset_create_p
         "font",
       ])
       .describe("Type of asset"),
-    destination: z.string().describe('Full res:// path including filename (e.g., "res://assets/knight/idle.png")'),
+    destination: z.string().describe('Full res:// path including filename (e.g., "res://assets/knight/idle.png" for images, "res://assets/mesh.tres" for models)'),
     prompt: z.string().describe("Generation prompt to use when generating"),
     negative_prompt: z.string().optional().describe("What to avoid"),
     provider: z.string().optional().describe("Override default provider"),
@@ -193,8 +196,18 @@ export const GodotAssetCreatePlaceholderTool = Tool.define("godot_asset_create_p
       .describe("Category for placeholder color"),
   }),
   async execute(params, ctx) {
-    const registry = AssetProviderRegistry.getInstance()
-    const resolved = registry.resolveModel(params.type as AssetProvider.AssetType, params.model)
+    // Try to resolve provider/model, but don't fail if providers aren't configured
+    // Placeholders can be created without providers - they'll be generated later
+    let resolved: { provider: AssetProvider.Provider; modelId: string } | undefined
+    try {
+      resolved = await AssetProviderRegistry.resolveModel(
+        params.type as AssetProvider.AssetType,
+        params.model,
+      )
+    } catch (error) {
+      // No providers configured - that's OK for placeholders
+      ctx.metadata({ title: "Creating placeholder (providers not configured)" })
+    }
 
     const projectRoot = Instance.directory
     let destPath = params.destination
@@ -210,6 +223,13 @@ export const GodotAssetCreatePlaceholderTool = Tool.define("godot_asset_create_p
       params.type as AssetProvider.AssetType,
       params.category ?? "default",
     )
+
+    // For non-image types (model, scene, shader, etc.), the placeholder uses a
+    // different extension (.tres, .tscn, .gdshader). Correct if needed.
+    const requestedExt = path.extname(destPath)
+    if (requestedExt !== placeholder.extension) {
+      destPath = destPath.slice(0, -requestedExt.length) + placeholder.extension
+    }
 
     // Write placeholder file
     await fs.writeFile(destPath, placeholder.content)
@@ -293,9 +313,8 @@ export const GodotAssetRegenerateTool = Tool.define("godot_asset_regenerate", {
     }
 
     // 2. Merge parameters
-    const registry = AssetProviderRegistry.getInstance()
     const providerId = existingMeta.provider
-    const provider = registry.getProvider(providerId!)
+    const provider = AssetProviderRegistry.get(providerId!)
     if (!provider) {
       return {
         title: "Regeneration failed",
@@ -415,13 +434,11 @@ export const GodotAssetTransformTool = Tool.define("godot_asset_transform", {
     }
 
     // Find provider that supports this transform
-    const registry = AssetProviderRegistry.getInstance()
-    const resolved = registry.resolveTransformProvider(
+    const providers = AssetProviderRegistry.findTransformProviders(
       params.transform as AssetProvider.TransformType,
-      params.model,
     )
 
-    if (!resolved) {
+    if (providers.length === 0) {
       return {
         title: "Transform failed",
         metadata: { error: "no_provider" },
@@ -429,7 +446,13 @@ export const GodotAssetTransformTool = Tool.define("godot_asset_transform", {
       }
     }
 
-    const { provider, modelId } = resolved
+    const provider = providers[0]
+    // Use provided model or get first available model from provider
+    let modelId = params.model
+    if (!modelId) {
+      const models = await provider.listModels()
+      modelId = models.length > 0 ? models[0].id : ""
+    }
 
     // Execute transform
     ctx.metadata({ title: `Transforming (${params.transform})...` })
@@ -453,8 +476,8 @@ export const GodotAssetTransformTool = Tool.define("godot_asset_transform", {
     if (status.status === "failed") {
       return {
         title: "Transform failed",
-        metadata: { error: status.message },
-        output: `Transform failed: ${status.message}`,
+        metadata: { error: status.message || "Unknown error" },
+        output: `Transform failed: ${status.message || "Unknown error"}`,
       }
     }
 
@@ -572,10 +595,8 @@ export const GodotAssetListModelsTool = Tool.define("godot_asset_list_models", {
       .describe("Filter by asset type"),
   }),
   async execute(params, ctx) {
-    const registry = AssetProviderRegistry.getInstance()
-
     if (params.provider) {
-      const models = await registry.listModels(params.provider)
+      const models = await AssetProviderRegistry.listModels(params.provider)
       return {
         title: `Models for ${params.provider}`,
         metadata: { provider: params.provider, count: models.length },
@@ -583,7 +604,7 @@ export const GodotAssetListModelsTool = Tool.define("godot_asset_list_models", {
       }
     }
 
-    const allModels = await registry.listAllModels()
+    const allModels = await AssetProviderRegistry.listAllModels()
 
     if (params.type) {
       // Filter to models that support this type
@@ -617,15 +638,15 @@ function generatePlaceholderContent(
   type: AssetProvider.AssetType,
   category: string,
 ): { content: Buffer; extension: string } {
-  // Color map for placeholder textures
+  // Color map for placeholder textures (0-255 RGBA)
   const categoryColors: Record<string, [number, number, number, number]> = {
-    character: [1, 0, 1, 1], // Magenta
-    environment: [0, 0.8, 0, 1], // Green
-    ui: [0, 1, 1, 1], // Cyan
-    item: [1, 0.5, 0, 1], // Orange
-    effect: [1, 1, 0, 1], // Yellow
-    skybox: [0.2, 0.4, 1, 1], // Blue
-    default: [0.6, 0.6, 0.6, 1], // Gray
+    character: [255, 0, 255, 255], // Magenta
+    environment: [0, 204, 0, 255], // Green
+    ui: [0, 255, 255, 255], // Cyan
+    item: [255, 128, 0, 255], // Orange
+    effect: [255, 255, 0, 255], // Yellow
+    skybox: [51, 102, 255, 255], // Blue
+    default: [153, 153, 153, 255], // Gray
   }
 
   const color = categoryColors[category] ?? categoryColors.default
@@ -634,24 +655,13 @@ function generatePlaceholderContent(
     case "texture":
     case "sprite":
     case "cubemap": {
-      // GradientTexture2D placeholder
-      const tres = `[gd_resource type="GradientTexture2D" format=3]
-
-[sub_resource type="Gradient" id="1"]
-colors = PackedColorArray(${color.join(", ")})
-
-[resource]
-gradient = SubResource("1")
-width = 64
-height = 64
-fill = 1
-`
-      return { content: Buffer.from(tres), extension: ".tres" }
+      // Generate a real 64x64 PNG with the category color
+      return { content: generateSolidPNG(64, 64, color), extension: ".png" }
     }
 
     case "model":
     case "mesh": {
-      // BoxMesh placeholder
+      // BoxMesh placeholder (native Godot resource)
       const tres = `[gd_resource type="BoxMesh" format=3]
 
 [resource]
@@ -674,7 +684,7 @@ mesh = SubResource("1")
 
     case "audio_sfx":
     case "audio_music": {
-      // Empty audio stream
+      // Empty audio stream (native Godot resource)
       const tres = `[gd_resource type="AudioStreamGenerator" format=3]
 
 [resource]
@@ -683,20 +693,22 @@ mesh = SubResource("1")
     }
 
     case "shader": {
+      const colorF = color.map((c) => (c / 255).toFixed(2))
       const gdshader = `shader_type spatial;
 
 void fragment() {
-    ALBEDO = vec3(${color[0]}, ${color[1]}, ${color[2]});
+    ALBEDO = vec3(${colorF[0]}, ${colorF[1]}, ${colorF[2]});
 }
 `
       return { content: Buffer.from(gdshader), extension: ".gdshader" }
     }
 
     case "material": {
+      const colorF = color.map((c) => (c / 255).toFixed(2))
       const tres = `[gd_resource type="StandardMaterial3D" format=3]
 
 [resource]
-albedo_color = Color(${color.join(", ")})
+albedo_color = Color(${colorF.join(", ")})
 `
       return { content: Buffer.from(tres), extension: ".tres" }
     }
@@ -713,4 +725,72 @@ albedo_color = Color(${color.join(", ")})
       return { content: Buffer.from(""), extension: ".txt" }
     }
   }
+}
+
+/** Generate a minimal valid PNG file filled with a solid RGBA color. */
+function generateSolidPNG(
+  width: number,
+  height: number,
+  color: [number, number, number, number],
+): Buffer {
+  const { deflateSync } = require("zlib") as typeof import("zlib")
+
+  // Build raw image data: filter byte (0) + RGBA pixels per row
+  const rowSize = 1 + width * 4
+  const rawData = Buffer.alloc(rowSize * height)
+  for (let y = 0; y < height; y++) {
+    const offset = y * rowSize
+    rawData[offset] = 0 // No filter
+    for (let x = 0; x < width; x++) {
+      const px = offset + 1 + x * 4
+      rawData[px] = color[0]
+      rawData[px + 1] = color[1]
+      rawData[px + 2] = color[2]
+      rawData[px + 3] = color[3]
+    }
+  }
+
+  const compressed = deflateSync(rawData)
+
+  // PNG chunks
+  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])
+
+  // IHDR: width, height, bit depth 8, color type 6 (RGBA)
+  const ihdrData = Buffer.alloc(13)
+  ihdrData.writeUInt32BE(width, 0)
+  ihdrData.writeUInt32BE(height, 4)
+  ihdrData[8] = 8 // bit depth
+  ihdrData[9] = 6 // color type: RGBA
+  ihdrData[10] = 0 // compression
+  ihdrData[11] = 0 // filter
+  ihdrData[12] = 0 // interlace
+  const ihdr = pngChunk("IHDR", ihdrData)
+
+  const idat = pngChunk("IDAT", compressed)
+  const iend = pngChunk("IEND", Buffer.alloc(0))
+
+  return Buffer.concat([signature, ihdr, idat, iend])
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const length = Buffer.alloc(4)
+  length.writeUInt32BE(data.length, 0)
+  const typeBuffer = Buffer.from(type, "ascii")
+  const crcInput = Buffer.concat([typeBuffer, data])
+  const crcValue = Buffer.alloc(4)
+  // Use a simple CRC32 implementation for PNG chunks
+  crcValue.writeUInt32BE(crc32PNG(crcInput) >>> 0, 0)
+  return Buffer.concat([length, typeBuffer, data, crcValue])
+}
+
+/** CRC32 for PNG (ISO 3309 / ITU-T V.42) */
+function crc32PNG(buf: Buffer): number {
+  let crc = 0xffffffff
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i]
+    for (let j = 0; j < 8; j++) {
+      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0)
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0
 }

--- a/packages/opencode/src/tool/godot-asset-import.ts
+++ b/packages/opencode/src/tool/godot-asset-import.ts
@@ -8,7 +8,9 @@ import { AssetProvider } from "../provider/asset/asset-provider"
 
 const DESCRIPTION = `Import user-provided asset files into the Godot project with AI metadata tracking.
 
-This tool copies external files into the project directory and creates metadata sidecars
+Import user-provided asset files into the Godot project with AI metadata tracking.
+
+This tool copies external files into the project directory and creates metadata
 for tracking asset origin, enabling the AI assistant to understand and manage project assets.
 
 Use this tool when:
@@ -19,7 +21,7 @@ Use this tool when:
 The tool automatically:
 1. Detects the asset type from file extension
 2. Copies the file to the specified project destination
-3. Creates a .ai.json metadata sidecar marking it as "imported"
+3. Creates .ai.{filename}/metadata.json marking it as "imported"
 4. Returns the res:// path for use in Godot`
 
 export const GodotAssetImportTool = Tool.define("godot_asset_import", {


### PR DESCRIPTION
## Summary
- Add Replicate provider with SD 3.5, SDXL, and FLUX models for 2D image/texture generation
- Extend asset provider registry with runtime configuration and 3-tier model resolution
- Add AI asset REST API routes (`/ai-assets`) for generation, status polling, download, transforms, and version management
- Enhance `godot_asset_generate` and related tools with Replicate integration

## Related
- Issue: hs3366677/makabaka-engine#5
- Godot PR: hs3366677/godot (feature/5-ai-powered-asset-generation)
- Main repo PR: hs3366677/makabaka-engine (feature/5-ai-powered-asset-generation)

## Test plan
- [ ] Build OpenCode with `bun run build --single`
- [ ] Start server and verify `/ai-assets/providers` returns Replicate
- [ ] Test asset generation with a configured Replicate API key
- [ ] Verify metadata and version management for generated assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)